### PR TITLE
Explicitly use LF line endings

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,6 +4,6 @@
         "target": "ESNext",
         "module": "CommonJS",
         "strict": true,
-
+        "newLine": "lf",
     }, "files": ["cli.ts"]
 }


### PR DESCRIPTION
Fixes #5 

Instead of using platform-specific line endings, always use LF line endings in emitted JavaScript.